### PR TITLE
merge/fixing-the-build to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "UI"]
 	path = UI
-	url = git://github.com/chaim1221/machete-ui.git
+	url = git://github.com/SavageLearning/machete-ui.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,8 @@ configuration:
   - Release
 
 # MSBuild settings; NOT a build step
-#build: 
+build: 
+  project: Machete.sln
 # dotnet build includes restore
 before_build:
   - sh: node --version


### PR DESCRIPTION
The branch was poorly named. The squash will show the merge name. Contains:

 - Get Machete.sln explicitly defined as the build sln in appveyor.yml
 - redirect submodule UI to point at `master` of SavageLearning/machete-ui