### PR TITLE
use Samesite=Strict

### DIFF
--- a/Machete.Web/Startup.cs
+++ b/Machete.Web/Startup.cs
@@ -238,7 +238,8 @@ namespace Machete.Web
             // This refers to the policies set in the services object. An invalid name will force the default policy.
             app.UseCors(StartupConfiguration.AllowCredentials);
             app.UseCookiePolicy(new CookiePolicyOptions {
-                MinimumSameSitePolicy = env.IsDevelopment() ? SameSiteMode.Lax : SameSiteMode.None
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#samesite_attribute
+                MinimumSameSitePolicy = env.IsDevelopment() ? SameSiteMode.Lax : SameSiteMode.Strict
             });
 
             app.UseAuthentication();

--- a/env_variables.conf
+++ b/env_variables.conf
@@ -3,6 +3,7 @@ COMPOSE_HTTP_TIMEOUT=120
 OPTDIR=./opt/
 SA_PASSWORD=passw0rD!
 SQLSERVER_CERT_SECRET=bigsecret
+ASPNETCORE_ENVIRONMENT=production
 MACHETE_Authentication__State=fakestate
 MACHETE_Authentication__Google__ClientSecret=something
 MACHETE_Authentication__Google__ClientId=something


### PR DESCRIPTION
Change: 
- Use `SameSite=Strict` instead of `SameSite=none`. `SameSite=None` requires the `Secure` attribute, but we don't actually need `SameSite=None`.
- Add ASPNETCORE_ENVIRONMENT` to docker-compose env variables

  #671 