### PR TITLE
redirect when to UI when auth fails

### DIFF
--- a/Machete.Web/Controllers/Api/Identity/IdentityController.cs
+++ b/Machete.Web/Controllers/Api/Identity/IdentityController.cs
@@ -224,7 +224,7 @@ namespace Machete.Web.Controllers.Api.Identity
 
                 var validateProfile = profile.email != null;
                 _logger.LogInformation($"{provider} login profile has a valid email?: {validateProfile}");
-                if (validateProfile) 
+                if (!validateProfile) 
                 {
                     _logger.LogWarning($"{provider} login failed!: {provider} profile did not contain an email");
                     result = false;

--- a/Machete.Web/Helpers/Api/Routes.cs
+++ b/Machete.Web/Helpers/Api/Routes.cs
@@ -24,6 +24,7 @@ namespace Machete.Web.Helpers.Api
         public static string FacebookSignin(string host) =>  $"{host.IdentityRoute()}signin-facebook";
         public static string GoogleSignin(string host) =>  $"{host.IdentityRoute()}signin-google";
         public static string V2AuthorizationEndpoint(this string host) => $"{host.V2Route()}authorize";
+        public static string V2FailedFacebookLoginEndpoint(this string host) => $"{host.V2Route()}welcome/fb-fail=true";
         public static string WellKnownConfigurationEndpoint(this string host) =>
             $"{host.WellKnownRoute()}openid-configuration";
         public static string JsonWebKeySetEndpoint(this string host) => $"{host.WellKnownRoute()}jwks";

--- a/Machete.Web/Helpers/Api/Routes.cs
+++ b/Machete.Web/Helpers/Api/Routes.cs
@@ -24,7 +24,7 @@ namespace Machete.Web.Helpers.Api
         public static string FacebookSignin(string host) =>  $"{host.IdentityRoute()}signin-facebook";
         public static string GoogleSignin(string host) =>  $"{host.IdentityRoute()}signin-google";
         public static string V2AuthorizationEndpoint(this string host) => $"{host.V2Route()}authorize";
-        public static string V2FailedFacebookLoginEndpoint(this string host) => $"{host.V2Route()}welcome/fb-fail=true";
+        public static string V2FailedFacebookLoginEndpoint(this string host) => $"{host.V2Route()}welcome/?fb-fail=true";
         public static string WellKnownConfigurationEndpoint(this string host) =>
             $"{host.WellKnownRoute()}openid-configuration";
         public static string JsonWebKeySetEndpoint(this string host) => $"{host.WellKnownRoute()}jwks";

--- a/Machete.Web/Helpers/Api/Routes.cs
+++ b/Machete.Web/Helpers/Api/Routes.cs
@@ -24,7 +24,7 @@ namespace Machete.Web.Helpers.Api
         public static string FacebookSignin(string host) =>  $"{host.IdentityRoute()}signin-facebook";
         public static string GoogleSignin(string host) =>  $"{host.IdentityRoute()}signin-google";
         public static string V2AuthorizationEndpoint(this string host) => $"{host.V2Route()}authorize";
-        public static string V2FailedFacebookLoginEndpoint(this string host) => $"{host.V2Route()}welcome/?fb-fail=true";
+        public static string V2FailedFacebookLoginEndpoint(this string host) => $"{host.V2Route()}welcome?fb-fail=true";
         public static string WellKnownConfigurationEndpoint(this string host) =>
             $"{host.WellKnownRoute()}openid-configuration";
         public static string JsonWebKeySetEndpoint(this string host) => $"{host.WellKnownRoute()}jwks";


### PR DESCRIPTION
### Changes:
- Redirects to V2 welcome endpoint (with a query string) to notify user that FB login failed
#673 