### PR TITLE
filter on skill codes

### DIFF
--- a/Machete.Selenium/Integration/HttpClientUtil/HttpClientUtil.cs
+++ b/Machete.Selenium/Integration/HttpClientUtil/HttpClientUtil.cs
@@ -88,6 +88,23 @@ namespace Machete.Test.Integration.HttpClientUtil
             }
             return lu.ID;
         }
+
+        public static List<Lookup> GetFirstThreeSkills(bool speciality)
+        {
+            var lus = _tenantLookupsCache
+                .Where(lu => lu.category == "skill" && lu.speciality == speciality)
+                .Take(3)
+                .ToList();
+            return lus;
+        }
+
+        public static List<Lookup> FilterSkills(Func<Lookup, bool> predicate)
+        {
+            var lus = _tenantLookupsCache
+                .Where(predicate)
+                .ToList();
+            return lus;
+        }
         
         public static string GetFirstLookupTextEn(int id)
         {

--- a/Machete.Selenium/Integration/Views/PersonTests.cs
+++ b/Machete.Selenium/Integration/Views/PersonTests.cs
@@ -12,6 +12,7 @@ using Machete.Domain;
 using Machete.Web.Maps;
 using Machete.Test.Integration.Fluent;
 using Machete.Test.Integration.HttpClientUtil;
+using Machete.Service;
 
 namespace Machete.Test.Selenium.View
 {
@@ -159,6 +160,27 @@ namespace Machete.Test.Selenium.View
             ui.activitySignIn(_act.idChild,_wkr.dwccardnum);
             //Assert
             Assert.IsTrue(ui.activitySignInIsSanctioned());
+        }
+
+        [TestMethod, TestCategory(TC.SE), TestCategory(TC.View), TestCategory(TC.Persons)]
+        public void SePerson_Filter_On_Skillcodes_returns_filtered_list()
+        {
+            //Arrange
+            var _per = (Web.ViewModel.Person)ViewModelRecords.person.Clone();
+            var _wkr = (Web.ViewModel.Worker)ViewModelRecords.worker.Clone();
+            _wkr.memberexpirationdate = DateTime.Now.AddYears(1);
+            _wkr.skill1 = HttpClientUtil.GetFirstThreeSkills(true)[0].ID;
+            _wkr.skill2 = HttpClientUtil.GetFirstThreeSkills(true)[1].ID;
+            _wkr.skill3 = HttpClientUtil.GetFirstThreeSkills(true)[2].ID;
+            _wkr.dwccardnum = sharedUI.nextAvailableDwccardnum(frb.ToFactory());
+
+            //Act
+            ui.personCreate(_per);
+            _wkr.ID = _per.ID;
+            ui.workerCreate(_wkr, testimagefile);
+
+            Worker dbWorker = frb.ToServ<IWorkerService>().Get(_wkr.ID);
+            Assert.IsTrue(ui.FilterWorker(_per, dbWorker));
         }
     }
 }

--- a/Machete.Service/PersonService.cs
+++ b/Machete.Service/PersonService.cs
@@ -55,7 +55,8 @@ namespace Machete.Service
             result.totalCount = q.Count();
             //
             //Search based on search-bar string 
-            if (!string.IsNullOrEmpty(o.sSearch)) IndexViewBase.search(o, ref q);
+            if (!string.IsNullOrEmpty(o.sSearch) && o.sSearch.Contains("skill:")) IndexViewBase.filterBySkill(o, ref q);
+            if (!string.IsNullOrEmpty(o.sSearch) && !o.sSearch.Contains("skill:")) IndexViewBase.search(o, ref q);
             if (o.showWorkers == true) IndexViewBase.getWorkers(o, ref q);
             if (o.showNotWorkers == true) IndexViewBase.getNotWorkers(o, ref q);
             if (o.showExpiredWorkers == true) {

--- a/Machete.Service/PersonService.cs
+++ b/Machete.Service/PersonService.cs
@@ -55,8 +55,7 @@ namespace Machete.Service
             result.totalCount = q.Count();
             //
             //Search based on search-bar string 
-            if (!string.IsNullOrEmpty(o.sSearch) && o.sSearch.Contains("skill:")) IndexViewBase.filterBySkill(o, ref q);
-            if (!string.IsNullOrEmpty(o.sSearch) && !o.sSearch.Contains("skill:")) IndexViewBase.search(o, ref q);
+            if (!string.IsNullOrEmpty(o.sSearch)) IndexViewBase.search(o, ref q);
             if (o.showWorkers == true) IndexViewBase.getWorkers(o, ref q);
             if (o.showNotWorkers == true) IndexViewBase.getNotWorkers(o, ref q);
             if (o.showExpiredWorkers == true) {

--- a/Machete.Service/Services/shared/IndexViewBase.cs
+++ b/Machete.Service/Services/shared/IndexViewBase.cs
@@ -488,13 +488,18 @@ namespace Machete.Service
         #region PERSONS
         public static void search(viewOptions o, ref IQueryable<Person> q)
         {
-            q = q
-                .Where(p => p.Worker.dwccardnum.ToString().Contains(o.sSearch) ||
-                            p.firstname1.Contains(o.sSearch) ||
-                            p.firstname2.Contains(o.sSearch) ||
-                            p.lastname1.Contains(o.sSearch) ||
-                            p.lastname2.Contains(o.sSearch) ||
-                            p.phone.Contains(o.sSearch));
+            if (o.sSearch.Contains("skill:"))
+            {
+                IndexViewBase.filterBySkill(o, ref q);
+            } else {
+                q = q
+                    .Where(p => p.Worker.dwccardnum.ToString().Contains(o.sSearch) ||
+                                p.firstname1.Contains(o.sSearch) ||
+                                p.firstname2.Contains(o.sSearch) ||
+                                p.lastname1.Contains(o.sSearch) ||
+                                p.lastname2.Contains(o.sSearch) ||
+                                p.phone.Contains(o.sSearch));
+            }
         }
         public static void sortOnColName(string name, bool descending, ref IQueryable<Person> q)
         {

--- a/Machete.Service/Services/shared/IndexViewBase.cs
+++ b/Machete.Service/Services/shared/IndexViewBase.cs
@@ -558,6 +558,47 @@ namespace Machete.Service
                             p.Person.lastname2.Contains(o.sSearch)
                             );
         }
+
+        public static void filterBySkill(viewOptions o, ref IQueryable<Person> q)
+        {
+            // expected skillcode: "skill: b, c, f"
+            string search = o.sSearch.Trim().Split("skill:")[1].ToLower();
+
+            if (search.Contains(","))
+            {
+                string skillCode1;
+                string skillCode2;
+                string skillCode3;
+
+                string[] skillCodes = search.Split(",");
+
+                if ( skillCodes.Length == 2)
+                {
+                    skillCode1 = skillCodes[0].Trim();
+                    skillCode2 = skillCodes[1].Trim();
+
+                    q = q.Where(p => p.Worker.skillCodes.Contains(skillCode1) &&
+                                    p.Worker.skillCodes.Contains(skillCode2));
+                }
+
+                if ( skillCodes.Length == 3)
+                {
+                    skillCode1 = skillCodes[0].Trim();
+                    skillCode2 = skillCodes[1].Trim();
+                    skillCode3 = skillCodes[2].Trim();
+
+                    q = q.Where(p => p.Worker.skillCodes.Contains(skillCode1) &&
+                                    p.Worker.skillCodes.Contains(skillCode2) &&
+                                    p.Worker.skillCodes.Contains(skillCode2));
+                }
+            
+            }
+            else
+            {
+                q = q.Where(p => p.Worker.skillCodes.Contains(search));
+            }
+        }
+
         public static void sortOnColName(string name, bool descending, ref IQueryable<Worker> q)
         {
             switch (name)

--- a/Machete.Test/Integration/Services/PersonServiceTest.cs
+++ b/Machete.Test/Integration/Services/PersonServiceTest.cs
@@ -88,5 +88,70 @@ namespace Machete.Test.Integration.Services
             Assert.IsNotNull(person.ID);
             Assert.IsTrue(reccount == 3, "Expected record count of 3, received {0}", reccount);
         }
+
+        [TestMethod, TestCategory(TC.IT), TestCategory(TC.Service), TestCategory(TC.Persons)]
+        public void GetIndexView_Filters_Workes_When_Skill_Codes_when_keyword_passed()
+        {
+            // Arrange
+            viewOptions vo = new viewOptions
+            {
+                sSearch = "skill: a, b ,c", // skill codes
+                sortColName = "text_EN",
+            };
+
+            var skill1 = frb.ToServ<ILookupService>().Create(new Lookup
+                {
+                    text_EN = "special skill 1",
+                    text_ES = "special skill 1",
+                    speciality = true,
+                    ltrCode = "a",
+                    level = 1,
+                    category = "skill",
+                    subcategory = "general",
+                    wage = 23,
+                    minHour = 3,
+                    typeOfWorkID = 20
+                }, "fake");
+            var skill2 = frb.ToServ<ILookupService>().Create(new Lookup
+                {
+                    text_EN = "special skill 2",
+                    text_ES = "special skill 2",
+                    ltrCode = "b",
+                    speciality = true,
+                    level = 1,
+                    category = "skill",
+                    subcategory = "general",
+                    wage = 23,
+                    minHour = 3,
+                    typeOfWorkID = 20
+                }, "fake");
+            var skill3 = frb.ToServ<ILookupService>().Create(new Lookup
+                {
+                    text_EN = "special skill 3",
+                    text_ES = "special skill 3",
+                    ltrCode = "c",
+                    speciality = true,
+                    level = 1,
+                    category = "skill",
+                    subcategory = "general",
+                    wage = 23,
+                    minHour = 3,
+                    typeOfWorkID = 20 
+                }, "fake");
+
+            var w = frb.AddWorker(skill1.ID, skill2.ID, skill3.ID);
+
+            // Act
+            dataTableResult<Service.DTO.PersonList> result = frb.ToServ<IPersonService>().GetIndexView(vo);
+
+            // Assert
+            Assert.IsTrue(result.filteredCount == 1);
+
+            // Clean up
+            frb.ToServ<ILookupService>().Delete(skill1.ID, "fake");
+            frb.ToServ<ILookupService>().Delete(skill2.ID, "fake");
+            frb.ToServ<ILookupService>().Delete(skill3.ID, "fake");
+            frb.ToServ<IWorkerService>().Delete(w.ID, "test");
+        }
     }
 }


### PR DESCRIPTION
### Changes:
#### Service layer
- catch a search keyword: `skill:` and search by comma-separated skill codes. Example: `skill: p1, p2, u2` or `skill: p1, p2` or `skill: u2`
- a work-around for a full-featured full-text search

#### Unit tests
- test service layer

#### integration test
- test filter on skill feature on the ui

<img width="928" alt="image" src="https://user-images.githubusercontent.com/26440947/162145060-96bf8d13-c43d-4782-889e-0ede4a8d021a.png">
